### PR TITLE
Issue #61: Fix Bug via changing DB naming conventions

### DIFF
--- a/server/dao/user.js
+++ b/server/dao/user.js
@@ -7,11 +7,11 @@ class UserDao {
     const {
       rows,
     } = await this.dbPool.query(
-      'INSERT INTO "User" (uEmail, uPassword) VALUES ($1, $2) RETURNING uId;',
+      'INSERT INTO rentr_user (email, password) VALUES ($1, $2) RETURNING id;',
       [email, password]
     );
 
-    const userId = rows[0].uid;
+    const userId = rows[0].id;
     return userId;
   };
   // getUser = (id) => {};

--- a/server/migrations/init.sql
+++ b/server/migrations/init.sql
@@ -6,19 +6,19 @@
 CREATE DATABASE rentr;
 \c rentr
 
-CREATE EXTENSION CITEXT;
+CREATE EXTENSION citext;
 
-CREATE TABLE IF NOT EXISTS "User" (
-    "uId" SERIAL PRIMARY KEY,
-    "uEmail" CITEXT UNIQUE NOT NULL,
-    "uPassword" VARCHAR(50) NOT NULL
+CREATE TABLE IF NOT EXISTS rentr_user (
+    id SERIAL PRIMARY KEY,
+    email CITEXT UNIQUE NOT NULL,
+    password VARCHAR(50) NOT NULL
 );
 
-INSERT INTO "User" ("uId", "uEmail", "uPassword") VALUES 
-(1, 'bosco@gmail.com', 'bosco123'),
-(2, 'justin@gmail.com', 'justin123'),
-(3, 'ronnie@gmail.com', 'ronnie123'),
-(4, 'azizul@gmail.com', 'azizul123'),
-(5, 'nathan@gmail.com', 'nathan123');
+INSERT INTO rentr_user(email, password) VALUES 
+('bosco@gmail.com', 'bosco123'),
+('justin@gmail.com', 'justin123'),
+('ronnie@gmail.com', 'ronnie123'),
+('azizul@gmail.com', 'azizul123'),
+('nathan@gmail.com', 'nathan123');
 
-SELECT * FROM "User";
+SELECT * FROM rentr_user;


### PR DESCRIPTION
### Associated Issues:
- Bug: #61 

### Description

This PR updates the naming convention for (i) table names & (ii) field names in the DB migration initialization script as follows:
Names of What? | Before | After
--- | --- | ---
Table | `"User"` | `rentr_user`
Field 1 | `"uId"` | `id`
Field 2 | `"uEmail"` | `email`
Field 3 | `"uPassword"` | `password`

### Main References
- [(Stack Exchange) PostgreSQL naming conventions](https://dba.stackexchange.com/a/245622)

### Output Screenshot

- **Results (After):**
![Screen Shot 2021-02-16 at 5 19 37 PM](https://user-images.githubusercontent.com/36612705/108134653-2ee5cd80-707c-11eb-87b0-734a0d35b4f7.png)


### Time spent
- 30m

### Github action
Closes #61 