### PR TITLE
Issue#79 jwt validation after login closes #79

### DIFF
--- a/server/api/routes/listing.js
+++ b/server/api/routes/listing.js
@@ -1,12 +1,13 @@
 const express = require('express');
 const { container } = require('../../di-setup');
 const validate = require('../../middleware/validate');
+const validateLoggedIn = require('../../middleware/validateLoggedIn');
 const listingDto = require('../../dto/listing');
 
 // --- get classes via container ---
 const listingController = container.resolve('listingController');
 
 const router = express.Router();
-router.post('/', validate(listingDto), listingController.addListing);
+router.post('/', validateLoggedIn, validate(listingDto), listingController.addListing);
 
 module.exports = router;

--- a/server/error/api-error.js
+++ b/server/error/api-error.js
@@ -8,6 +8,10 @@ class ApiError {
     return new ApiError(400, msg);
   }
 
+  static unAuthenticated(msg) {
+    return new ApiError(401, msg);
+  }
+
   static notFound(msg) {
     return new ApiError(404, msg);
   }

--- a/server/middleware/validate.js
+++ b/server/middleware/validate.js
@@ -6,7 +6,6 @@ const validate = (schema) => (req, res, next) => {
   // req.body is invalid
   if (error) {
     next(ApiError.badRequest(error));
-    return;
   }
   // req.body is valid
   req.body = value;

--- a/server/middleware/validateLoggedIn.js
+++ b/server/middleware/validateLoggedIn.js
@@ -1,0 +1,16 @@
+const jwt = require('jsonwebtoken');
+const ApiError = require('../error/api-error');
+
+const validateLoggedIn = (req, res, next) => {
+  try {
+    const token = req.headers.authorization.split(' ')[1];
+    const decoded = jwt.verify(token, process.env.JWT_KEY);
+    req.userData = decoded;
+    next();
+  } catch (err) {
+    // Invalid auth token, meaning not logged in
+    next(ApiError.unAuthenticated('You need to be logged in to do this.'));
+  }
+};
+
+module.exports = validateLoggedIn;


### PR DESCRIPTION
**Description** 
After a user has been logged in, they receive a JWT Token. 
This token must be used to authenticate the user when they try to access certain routes.

**Changelog**
- Added ```validateLoggedIn``` Middleware
  - Checks for the JWT Token in the Header (Authorization).
- Added said Middleware to POST ```addListing``` route. 

**Screenshots**
The user receives a token upon successful login.
![image](https://user-images.githubusercontent.com/24920297/108781181-1b7cab80-752f-11eb-9185-de3780a4265a.png)

That token is included in the Authorization Header when accessing certain routes. 
(Currently only the POST ```addListing``` route.)
![image](https://user-images.githubusercontent.com/24920297/108781382-61d20a80-752f-11eb-8149-d6665286a8db.png)

When a token is invalid (or missing). The authorization fails and access is denied. 
- Removal of first letter of token -> Making it invalid
![image](https://user-images.githubusercontent.com/24920297/108781567-b07fa480-752f-11eb-9f10-b1ccdba2e5b9.png)
 
- Missing token
![image](https://user-images.githubusercontent.com/24920297/108781628-cee5a000-752f-11eb-9e8a-be96aedecb69.png)
