### PR TITLE
Issue #90: Initial Travis-CI Setup  

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ node_js:
 env:
   - TEST_DIR=frontend
   - TEST_DIR=server
-script: cd $TEST_DIR && npm install
+script: cd $TEST_DIR && npm install && npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - 14
+env:
+  - TEST_DIR=frontend
+  - TEST_DIR=server
+script: cd $TEST_DIR && npm install

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,0 @@
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,0 +1,4 @@
+test('dummy first test for travis-ci', () => {
+  const dummy = true;
+  expect(dummy).toBe(true);
+});


### PR DESCRIPTION
### Associated Issues:
- User Stories: N/A
- Dev Tasks: #90

### Description

This PR aims to do an initial setup on Travis-CI, which consists of the following subtasks:
- [X] Add `.travis.yml` which instructs Travis-CI to build for both the frontend and the backend.
- [X] Front-end
   - [X] Remove default `App.test.js`
      - Keeping it will break the build since there is no "learn react.js" text on the webpage.
   - [X] Add dummy initial test case
      - `npm test` with zero tests would break the build. That's why we need this.
- [X] Back-end
   - [X] Remove empty test file `/dao/user.test.js`
      - Test file with no test cases inside would break the build. 

### Main References
- [Testing Multiple Subdirectories with Travis-CI](https://lord.io/blog/2014/travis-multiple-subdirs/)
- [Travis CI - Building a JavaScript and Node.js project](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/)

### Other References
- [Deploy React App to your server with Travis CI](https://rharshad.com/deploy-react-app-travis/#:~:text=Travis%20CI%20is%20a%20hosted,at%20Github%20using%20Travis%20CI.)
- [Travis CI - Heroku Deployment](https://docs.travis-ci.com/user/deployment/heroku/)

### Output Screenshot

- **Travis-CI Build**
![Screen Shot 2021-02-24 at 4 05 53 PM](https://user-images.githubusercontent.com/36612705/109072929-53b0f500-76bb-11eb-8057-ed39d86066ff.png)

### Time spent
- 3h

### Github action
close #90 