### PR TITLE
Issue #97: Fix Login Bug when invalid combination between email and password are entered. 

### DIFF
--- a/server/controllers/user.js
+++ b/server/controllers/user.js
@@ -73,6 +73,9 @@ class UserController {
           token,
         });
       }
+      next(
+        ApiError.unauthenticated(`The login email or password is not valid.`)
+      );
     } catch (err) {
       next(ApiError.internal(`${err}`));
     }


### PR DESCRIPTION
### Associated Issues:
- User Stories: N/A
- Bugs: #97 

### Description

This PR aims to resolve the "hanging-forever" problem when the POST Login API is called with invalid login credentials (email & password), by adding extra `next(...)` after the `else-if-condition`, i.e. when the credentials does not match the one from the DB.

### Main References
- N/A

### Output Screenshot
- **Before**
![Screen Shot 2021-02-25 at 8 57 14 PM](https://user-images.githubusercontent.com/36612705/109249690-d3b78780-77ad-11eb-90bf-2426d321d897.png)

- **After**
![Screen Shot 2021-02-25 at 9 09 22 PM](https://user-images.githubusercontent.com/36612705/109249631-b387c880-77ad-11eb-8de0-51418028d5cc.png)

### Time spent
- 30m

### Github action
close #97