### PR TITLE
Add listing main view container

### DIFF
--- a/frontend/src/components/Listing/listing.jsx
+++ b/frontend/src/components/Listing/listing.jsx
@@ -19,7 +19,7 @@ import { Typography } from "@material-ui/core";
 import Pagination from '@material-ui/lab/Pagination';
 import ApartmentIcon from '@material-ui/icons/Apartment';
 import LocalParkingIcon from '@material-ui/icons/LocalParking';
-import {API_ROOT_GET} from "../../data/urls";
+import { API_ROOT_GET } from "../../data/urls";
 
 import "../../styles/Listing.css";
 
@@ -125,16 +125,18 @@ class Listing extends Component {
                           alt="apartment"
                         />
                     }
-                      
                   </span>
 
                   <div className = "listingTextAndIcon">
-                    <span className = "listingHeader">
-                    
+                    <div className = "listingHeader">
+
                       {/* This is for the listing title area */}
-                      <span className = "listingTitle">
+                      <div className="listingTitle" style={{
+                        width: '40%',
+                        wordWrap: 'break-word'
+                      }}>
                         {listingDetail.title}
-                      </span>
+                      </div>
 
                       <Typography
                         type="title"
@@ -143,14 +145,14 @@ class Listing extends Component {
                           flex: 1 
                         }}
                       />
-                
+                      
                       {/* This is for the listing icon area */}
                       <span className = "listingIconGroup">
                         {/* number of washrooms*/}
                         <span className = "listingIconNumber">
                           {listingDetail.num_bathroom}
                           <Tooltip title = "Washroom">
-                            <BathtubIcon className = "listingIcon" fontSize = "large"/>
+                            <BathtubIcon className = "listingIcon" fontSize = "medium"/>
                           </Tooltip>
                         </span>
 
@@ -158,7 +160,7 @@ class Listing extends Component {
                         <span className = "listingIconNumber">
                           {listingDetail.num_bedroom}
                           <Tooltip title = "Bedroom">
-                            <HotelIcon className = "listingIcon" fontSize = "large"/>
+                            <HotelIcon className = "listingIcon" fontSize = "medium"/>
                           </Tooltip>
                         </span>
                         
@@ -171,7 +173,7 @@ class Listing extends Component {
                               <LocalLaundryServiceIcon 
                                 style = {{color: "green"}}
                                 className = "listingIcon" 
-                                fontSize = "large"
+                                fontSize = "medium"
                               />
                             </Tooltip>
                             :
@@ -179,7 +181,7 @@ class Listing extends Component {
                               <LocalLaundryServiceIcon
                                 style = {{color: "grey"}}
                                 className = "listingIcon" 
-                                fontSize = "large"
+                                fontSize = "medium"
                               />
                             </Tooltip>
                           }
@@ -192,14 +194,16 @@ class Listing extends Component {
                             ? 
                             <Tooltip title = "Pet allowed">
                               <PetsIcon
-                                style = {{color: "green"}}
+                                style={{ color: "green" }}
+                                fontSize = "small"
                                 className = "listingIconNumber"
                               />
                             </Tooltip>
                             :
                             <Tooltip title = "Pet NOT allowed">
                               <PetsIcon
-                                style = {{color: "grey"}}
+                                style={{ color: "grey" }}
+                                fontSize = "small"
                                 className = "listingIconNumber"
                               />
                             </Tooltip>
@@ -213,14 +217,16 @@ class Listing extends Component {
                             ? 
                             <Tooltip title = "Parking is included">
                               <LocalParkingIcon
-                                style = {{color: "green"}}
+                                style={{ color: "green" }}
+                                fontSize = "small"
                                 className = "listingIconNumber"
                               />
                             </Tooltip>
                             :
                             <Tooltip title = "Parking NOT included">
                               <LocalParkingIcon
-                                style = {{color: "grey"}}
+                                style={{ color: "grey" }}
+                                fontSize = "small"
                                 className = "listingIconNumber"
                               />
                             </Tooltip>
@@ -237,7 +243,7 @@ class Listing extends Component {
                         ${this.checkPrice(listingDetail.price)}
                       </div>
 
-                    </span>
+                    </div>
 
                     <Divider/>
 

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -16,6 +16,7 @@ import MenuList from '@material-ui/core/MenuList';
 import MenuItem from '@material-ui/core/MenuItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ExitToAppIcon from '@material-ui/icons/ExitToApp';
+import Box from '@material-ui/core/Box';
 
 import CreateListingButton from "../components/CreateListing/CreateListingButton";
 import LoginDialogButton from "../components/LoginDialogButton";
@@ -62,7 +63,15 @@ class HomePage extends Component {
           </Toolbar>
 
         </AppBar>
-        <HomeContent />
+        <Box display="flex" flexDirection="row" p={1} m={1} bgcolor="background.paper">
+          <Box border={1} m={1} style={{width:'50%'}}>
+            <HomeContent />
+          </Box>
+          <Box border={1} m={1} style={{width: '50%'}}>
+            Stuff here!
+          </Box>
+        </Box>
+        
       </div>
     )
   }

--- a/frontend/src/styles/Listing.css
+++ b/frontend/src/styles/Listing.css
@@ -48,7 +48,7 @@
 }
 
 .listingTitle{
-  font-size: 28px;
+  font-size: 16px;
   font-weight: 700;
   white-space: nowrap;
   overflow: hidden;
@@ -61,11 +61,11 @@
 .listingIconNumber{
   display: flex;
   align-items: center;
-  margin-left: 10px;
-  margin-right: 10px;
-  font-size: larger;
-  width: 60px;
-  font-weight: 700;
+  margin-left: 5px;
+  margin-right: 5px;
+  font-size: medium;
+  width: 50px;
+  font-weight: 500;
 }
 
 .listingPrice{
@@ -94,7 +94,7 @@
 }
 
 .listingDescription{
-  font-size: 19px;
+  font-size: 14px;
   display: -webkit-box;
   max-width: 100%;
   height: 95px;


### PR DESCRIPTION
This will allow a space for us to place the Q&A section of a listing, its full title and description, and its images. 

Some styling changes have been made for the now-left-hand side of the screen so that it fits within its box. These changes aren't meant to be final. They are just so everything fits. 

![image](https://user-images.githubusercontent.com/51212155/112226685-7a037b00-8bfc-11eb-938a-48ab358ef772.png)
