### PR TITLE
Issue #142: Filter listing via keywords

### DIFF
--- a/server/dao/listing.js
+++ b/server/dao/listing.js
@@ -40,7 +40,11 @@ class ListingDao {
           COALESCE($6 >= rentr_listing.num_bathroom, TRUE) AND
           COALESCE($7 = rentr_listing.is_laundry_available, TRUE) AND
           COALESCE($8 = rentr_listing.is_pet_allowed, TRUE) AND
-          COALESCE($9 = rentr_listing.is_parking_available, TRUE)
+          COALESCE($9 = rentr_listing.is_parking_available, TRUE) AND
+          CASE WHEN ($10 <> '') IS NOT TRUE
+            THEN TRUE
+            ELSE to_tsvector(rentr_listing.title) @@ to_tsquery($10) 
+          END
         ;
       `,
       [
@@ -53,6 +57,7 @@ class ListingDao {
         query.is_laundry_available,
         query.is_pet_allowed,
         query.is_parking_available,
+        query.keywords,
       ]
     );
     return rows;

--- a/server/dto/listingReqQueryString.js
+++ b/server/dto/listingReqQueryString.js
@@ -11,6 +11,7 @@ const schema = joi.object({
   is_laundry_available: joi.boolean().default(null),
   is_pet_allowed: joi.boolean().default(null),
   is_parking_available: joi.boolean().default(null),
+  keywords: joi.string().regex(/^[a-zA-Z0-9]*$/).allow("").default("")
 });
 
 module.exports = schema;

--- a/server/middleware/validateReqQueryString.test.js
+++ b/server/middleware/validateReqQueryString.test.js
@@ -13,6 +13,7 @@ test('should replace req.query with the JOI validation results if the validation
       min_price: '100',
       max_price: 9999,
       is_laundry_available: true,
+      keywords: "expensive"
     },
   });
   const res = mockResponse();
@@ -33,6 +34,7 @@ test('should replace req.query with the JOI validation results if the validation
       max_num_bedroom: null,
       is_pet_allowed: null,
       is_parking_available: null,
+      keywords: "expensive"
     })
   );
   expect(next).toHaveBeenCalled();


### PR DESCRIPTION
### Associated Issues:
- User Stories: #33
- Dev Tasks: #142 

### Description

This PR aims to provide filtering feature for GET `/api/v1/listing` request. This PR is responsible for filtering the results via full-text search based on `keywords`. Currently, only single full-word search would be allowed, i.e. no space is allowed in this `keywords` field.  Also, `keywords` must be a full word, i.e. "exp" cannot be used for finding listing with "expensive" in the title. 

This PR makes changes on the following files for this filtering functionality:
- Dto (ListingReqQueryString):
   - `dto/listingReqQueryString.js`
- Dao (Listing): `dao/listing.js`
- Others:
   - Unit Test: `middleware/validateReqQueryString.test.js`

### Main References

##### Database & SQL (Full-Text Search)

- [Mastering PostgreSQL Tools: Full-Text Search and Phrase Search](https://www.compose.com/articles/mastering-postgresql-tools-full-text-search-and-phrase-search/)
- [PostgreSQL 8.4.22 Documentation - 9.16. Conditional Expressions](https://www.postgresql.org/docs/8.4/functions-conditional.html)
- [Quick-Start: Regex Cheat Sheet](https://www.rexegg.com/regex-quickstart.html)
- [(StackOverflow) Best way to check for “empty or null value”](https://stackoverflow.com/a/23767625)

### Output Screenshot (WIP)

- Listing without filtering - `localhost:5001/api/v1/listing?`:
![Screen Shot 2021-03-24 at 4 58 30 PM](https://user-images.githubusercontent.com/36612705/112390969-214be500-8cc5-11eb-931c-a05245b969dc.png)

- Listing with filtering via keywords (valid - empty string) - `localhost:5001/api/v1/listing?keywords=`:
![Screen Shot 2021-03-24 at 5 22 29 PM](https://user-images.githubusercontent.com/36612705/112391061-4c363900-8cc5-11eb-9cbe-e47a9e8865e1.png)

- Listing with filtering via keywords (valid - full word - "expensive") - `localhost:5001/api/v1/listing?keywords=expensive`:
![Screen Shot 2021-03-24 at 5 23 13 PM](https://user-images.githubusercontent.com/36612705/112391117-64a65380-8cc5-11eb-9da7-7b6c0f5816b4.png)

- Listing with filtering via keywords (valid but won't match - not a word - "exp") - `localhost:5001/api/v1/listing?keywords=exp`:
![Screen Shot 2021-03-24 at 5 23 45 PM](https://user-images.githubusercontent.com/36612705/112391159-7a1b7d80-8cc5-11eb-973d-5b6e3f16009d.png)

- Listing with filtering via keywords (invalid - with space in between  - "expensive house") - `localhost:5001/api/v1/listing?keywords=expensive house`:
![Screen Shot 2021-03-24 at 5 24 38 PM](https://user-images.githubusercontent.com/36612705/112391222-94edf200-8cc5-11eb-960c-c126faef2609.png)

- Listing with filtering via keywords & range - `localhost:5001/api/v1/listing?keywords=appartment&min_price=20`:
![Screen Shot 2021-03-24 at 5 25 09 PM](https://user-images.githubusercontent.com/36612705/112391286-a931ef00-8cc5-11eb-823d-d38e0ab2151d.png)

- Passing all Unit Testing:
![Screen Shot 2021-03-24 at 5 25 58 PM](https://user-images.githubusercontent.com/36612705/112391350-c666bd80-8cc5-11eb-9b32-037f81eb7cbf.png)

### Time spent
- 1.5h

### Github action
close #142 