### PR TITLE
Issue #136: Update SQL script for chain & comment tables

### DIFF
--- a/server/migrations/init.sql
+++ b/server/migrations/init.sql
@@ -8,6 +8,8 @@ CREATE DATABASE rentr;
 
 CREATE EXTENSION citext;
 
+DROP TABLE rentr_comment;
+DROP TABLE rentr_chain;
 DROP TABLE rentr_listing;
 DROP TABLE rentr_user;
 
@@ -47,3 +49,42 @@ INSERT INTO rentr_listing(userid, title, price, num_bedroom, num_bathroom, is_la
 (2, 'Serious appartment', 320, 3, 2, TRUE, TRUE, FALSE, ARRAY['this_is_the_image_url.com'], 'An appartment closed to the university and the bus stop. Contact me!');
 
 SELECT * FROM rentr_listing;
+
+CREATE TABLE IF NOT EXISTS rentr_chain (
+    id BIGSERIAL PRIMARY KEY NOT NULL,
+    userid BIGINT NOT NULL, 
+    listingid BIGINT NOT NULL,
+    CONSTRAINT fk_user FOREIGN KEY (userid) REFERENCES rentr_user(id),
+    CONSTRAINT fk_listing FOREIGN KEY (listingid) REFERENCES rentr_listing(id)
+);
+
+CREATE TABLE IF NOT EXISTS rentr_comment (
+    id BIGSERIAL PRIMARY KEY NOT NULL,
+    userid BIGINT NOT NULL,
+    listingid BIGINT NOT NULL,
+    chainid BIGINT NOT NULL,
+    content VARCHAR CHECK (length(content) <= 1000) NOT NULL,
+    CONSTRAINT fk_user FOREIGN KEY (userid) REFERENCES rentr_user(id),
+    CONSTRAINT fk_listing FOREIGN KEY (listingid) REFERENCES rentr_listing(id),
+    CONSTRAINT fk_chain FOREIGN KEY (chainid) REFERENCES rentr_chain(id)
+);
+
+INSERT INTO rentr_chain(userid, listingid) VALUES
+(3, 1),
+(2, 1),
+(4, 2);
+
+INSERT INTO rentr_comment(userid, listingid, chainid, content) VALUES
+(3, 1, 1, 'Tenant (uid=3) | Comment 1 in Chain 1 in Listing 1'),
+(1, 1, 1, 'Landlord (uid=1) | Comment 2 in Chain 1 in Listing 1'),
+(3, 1, 1, 'Tenant (uid=3) | Comment 3 in Chain 1 in Listing 1'),
+(2, 1, 1, 'Another Tenant (uid=2) | Comment 4 in Chain 1 in Listing 1'),
+(2, 1, 2, 'Tenant (uid=2) | Comment 5 in Chain 2 in Listing 1'),
+(1, 1, 2, 'Landlord (uid=1) | Comment 6 in Chain 2 in Listing 1'),
+(1, 1, 2, 'Landlord (uid=1) | Comment 7 in Chain 2 in Listing 1'),
+(1, 1, 2, 'Landlord (uid=1) | Comment 8 in Chain 2 in Listing 1'),
+(4, 2, 3, 'Tenant (uid=4) | Comment 9 in Chain 3 in Listing 2');
+
+SELECT * FROM rentr_chain;
+
+SELECT * FROM rentr_comment;


### PR DESCRIPTION
### Associated Issues:
- User Stories: #119 #120  
- Dev Tasks: #136

### Description

This PR updates the SQL initialization script, `migrations/init.sql`, such that a `chain` table & a `comment` would be created when running that script.

##### Relationship
- Listing is having 1-to-many relationship to Chain.
- Listing is having 1-to-many relationship to Comment.
- Chain is having 1-to-many relationship to Comment.
- User is having 1-to-many relationship to Chain.
- User is having 1-to-many relationship to Comment.

### Main References

##### Database & SQL
- [How To Implement One to One, One to Many and Many to Many Relationships When Designing A Database.](https://medium.com/@emekadc/how-to-implement-one-to-one-one-to-many-and-many-to-many-relationships-when-designing-a-database-9da2de684710)

### Output Screenshot

- Results:
![Screen Shot 2021-03-24 at 10 11 25 PM](https://user-images.githubusercontent.com/36612705/112420824-e4e7ab80-8cfb-11eb-88ab-d588f75b958c.png)

### Time spent
- 2h

### Github action
close #136 