### PR TITLE
Issue #138: Implement GET listing comments route

### DIFF
--- a/server/api/routes/listing.js
+++ b/server/api/routes/listing.js
@@ -25,6 +25,7 @@ router.post(
   validate(listingDto),
   listingController.addListing
 );
+router.get('/:id/comment', listingController.getListingCommentsViaListingId);
 router.post(
   '/:id/chain',
   validateLoggedIn,

--- a/server/controllers/listing.js
+++ b/server/controllers/listing.js
@@ -1,8 +1,9 @@
 const ApiError = require('../error/api-error');
 
 class ListingController {
-  constructor({ listingService }) {
+  constructor({ listingService, commentService }) {
     this.listingService = listingService;
+    this.commentService = commentService;
   }
 
   addListing = async (req, res, next) => {
@@ -35,6 +36,18 @@ class ListingController {
         return;
       }
       res.status(200).json(listing);
+    } catch (err) {
+      next(ApiError.internal(`${err}`));
+    }
+  };
+
+  getListingCommentsViaListingId = async (req, res, next) => {
+    try {
+      const listinId = req.params.id;
+      const comments = await this.commentService.getCommentsViaListingId(
+        listinId
+      );
+      res.status(200).json(comments);
     } catch (err) {
       next(ApiError.internal(`${err}`));
     }

--- a/server/controllers/listing.js
+++ b/server/controllers/listing.js
@@ -43,9 +43,9 @@ class ListingController {
 
   getListingCommentsViaListingId = async (req, res, next) => {
     try {
-      const listinId = req.params.id;
+      const listingId = req.params.id;
       const comments = await this.commentService.getCommentsViaListingId(
-        listinId
+        listingId
       );
       res.status(200).json(comments);
     } catch (err) {

--- a/server/dao/comment.js
+++ b/server/dao/comment.js
@@ -16,6 +16,19 @@ class CommentDao {
     const commentId = rows[0].id;
     return commentId;
   };
+
+  getCommentsViaListingId = async (listingId) => {
+    const res = await this.dbPool.query(
+      `
+        SELECT * 
+        FROM rentr_comment
+        WHERE listingid = $1;
+      `,
+      [listingId]
+    );
+    const { rows } = res;
+    return rows;
+  };
 }
 
 module.exports = CommentDao;

--- a/server/services/comment.js
+++ b/server/services/comment.js
@@ -5,6 +5,9 @@ class CommentService {
 
   createComment = (userId, listingId, chainId, body) =>
     this.commentDao.createComment(userId, listingId, chainId, body);
+
+  getCommentsViaListingId = (listingId) =>
+    this.commentDao.getCommentsViaListingId(listingId);
 }
 
 module.exports = CommentService;


### PR DESCRIPTION
### Associated Issues:
- User Stories: #119, #120 
- Dev Tasks: #138 

### Description

This PR aims to implement a GET route for retrieving all comments associated to a listing:
1. `GET /api/v1/listing/:id/comment` (Getting all comments associated to that listing)

The following places have been modified for adding these two POST request:
- Route: `api/routes/listing.js`
- Controller: `controllers/listing.js`
- Service: `services/comment.js`
- Dao: `dao/chain.js`

### Main References

N/A

### Output Screenshot

- GET all comments - `localhost:5001/api/v1/listing/:id/comment`
![Screen Shot 2021-03-25 at 9 51 19 PM](https://user-images.githubusercontent.com/36612705/112571107-59325580-8db5-11eb-9c3d-53c21530840e.png)

### Time spent
- 1.5h

### Github action
close #138 