### PR TITLE
Fix landlord reply check

### DIFF
--- a/frontend/src/components/ListingViewer/ListingViewer.jsx
+++ b/frontend/src/components/ListingViewer/ListingViewer.jsx
@@ -610,7 +610,7 @@ class ListingViewer extends Component {
     for (let i = 0 ; i < question.replies.length; i++){
       result.push(
         <div className="answerQnA" style={{backgroundColor: (i % 2 === 0) ? '#EEEFFF' : '#white' }}>
-          {(question.replies[i].userid === this.props.selectedListing.userid)
+          {(question.replies[i].userid === (this.props.selectedListing.userid).toString())
             ?
             <div className="landlordText">⭐landlord replied:</div>
             :


### PR DESCRIPTION
Previously, if a landlord replied in a QnA section, it would say that a user replied, not the landlord. Now it correctly says that a landlord replied. 

![image](https://user-images.githubusercontent.com/51212155/112668771-e2d13a00-8e2c-11eb-8b3f-07e98057fedc.png)
