### PR TITLE
Issue 189 disable search spaces

### DIFF
--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -85,8 +85,13 @@ class HomePage extends Component {
                 marginRight: 20,
                 marginLeft: 30
               }}
+              onKeyPress={(e) => {
+                if (e.which === 32) { //32 is the space character
+                  e.preventDefault()
+                }
+              }}
               error = {this.props.searchFieldError}
-              placeholder = "Search with keywords"
+              placeholder = "Enter a keyword"
               onChange={e => {
                 if(this.props.searchFieldError){
                   this.props.setSearchError(false)


### PR DESCRIPTION
Currently search will fail if the user puts spaces in their search. This could be mistaken for a bug if the user types in a full listing name and nothing shows up

This removes the user's ability to type in spaces and changes the text to suggest that only one keyword can be written.

![image](https://user-images.githubusercontent.com/51212155/113938142-cdaac280-97bf-11eb-9451-da95db3cfb07.png)

resolves #189